### PR TITLE
Fix package and flake install example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can add Nilla CLI as a Flake input.
 # flake.nix
 {
   inputs = {
-    nilla-cli.url = "github:nilla-nix/nilla";
+    nilla-cli.url = "github:nilla-nix/cli";
   };
 
   outputs = { nilla-cli, ... }:

--- a/nilla.nix
+++ b/nilla.nix
@@ -8,8 +8,8 @@ nilla.create {
     inputs = {
       nixpkgs = {
         src = builtins.fetchTarball {
-          url = "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz";
-          sha256 = "0aa89pl1xs0kri9ixxg488n7riqi5n9ys89xqc0immyqshqc1d7f";
+          url = "https://github.com/NixOS/nixpkgs/archive/c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5.tar.gz";
+          sha256 = "1sfb9g6fmyfligcsd1rmkamfqvy8kgn3p0sy8ickf6swi1zdbf0b";
         };
 
         loader = "legacy";


### PR DESCRIPTION
I noticed that the flake install example URL was wrong, if you try to lock the nilla repo instead of this repo, you get an error due to the mising flake.nix file
```
error:
       … while updating the lock file of flake 'git+file:///home/vera/Projects/GradientOS'

       … while updating the flake input 'nilla-cli'

       error: source tree referenced by 'github:nilla-nix/nilla/05fbaa811cd33e93861b43edcd6dfa45a6850afc' does not contain a '/flake.nix' file
```

Although even with this fix, I still can't quite get it to work on my end hmm, might be an user error though
```
       error: attribute 'packages' missing
       at /nix/store/affqiwqi1lj9697v1wg2w68zz0kxx0x4-source/modules/profiles/default.nix:38:35:
           37|       ])
           38|       self.inputs.nilla-cli.nilla.packages.nilla.${system}
```