### PR TITLE
fix: use nixpkgs source from npins

### DIFF
--- a/nilla.nix
+++ b/nilla.nix
@@ -7,10 +7,7 @@ nilla.create {
   config = {
     inputs = {
       nixpkgs = {
-        src = builtins.fetchTarball {
-          url = "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz";
-          sha256 = "0aa89pl1xs0kri9ixxg488n7riqi5n9ys89xqc0immyqshqc1d7f";
-        };
+        src = pins.nixpkgs;
 
         loader = "legacy";
 


### PR DESCRIPTION
As reported in #1, the hard-coded parameters to the fetcher in `nilla.nix` can fail non-deterministically. We already have a nice, minimal solution to these types of issues in `npins` so let's use and promote it