### PR TITLE
feat(Paths): Move to dynamic Path objects

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -82,7 +82,7 @@ pub async fn run_cmd(cli: &nilla_cli_def::Cli, args: &nilla_cli_def::commands::r
     let mut binary_path = PathBuf::from(value[0].clone());
     binary_path.push("bin");
     binary_path.push(main);
-    trace!("Binary path: {:?}", binary_path.as_os_str());
+    trace!("Binary path: {:?}", path.as_os_str());
     info!("Running Package {name}");
 
     let command_args = &args.remaining;

--- a/src/util/git.rs
+++ b/src/util/git.rs
@@ -2,7 +2,11 @@ use std::path::PathBuf;
 
 use tokio::process::Command;
 
-pub(crate) async fn get_untracked_files(repo: &PathBuf) -> anyhow::Result<Vec<PathBuf>> {
+pub(crate) async fn get_untracked_files<P>(repo: P) -> anyhow::Result<Vec<PathBuf>>
+where
+    P: Into<PathBuf>,
+{
+    let repo: PathBuf = repo.into();
     let output = Command::new("git")
         .arg("ls-files")
         .arg("--others")

--- a/src/util/search.rs
+++ b/src/util/search.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 
-pub fn search_up_for_file(start: &PathBuf, file: &str) -> Option<PathBuf> {
-    let mut current = start.clone();
+pub fn search_up_for_file<P>(start: P, file: &str) -> Option<PathBuf>
+where
+    P: Into<PathBuf>,
+{
+    let mut current: PathBuf = start.into();
     loop {
         let candidate = current.join(file);
         if candidate.is_file() {
@@ -13,8 +16,11 @@ pub fn search_up_for_file(start: &PathBuf, file: &str) -> Option<PathBuf> {
     }
 }
 
-pub fn search_up_for_dir(start: &PathBuf, dir: &str) -> Option<PathBuf> {
-    let mut current = start.clone();
+pub fn search_up_for_dir<P>(start: P, dir: &str) -> Option<PathBuf>
+where
+    P: Into<PathBuf>,
+{
+    let mut current: PathBuf = start.into();
     loop {
         let candidate = current.join(dir);
         if candidate.is_dir() {


### PR DESCRIPTION
Instead of requiring the passed argument to be a PathBuf we now have two cases,
1. The path gets modified after it gets passed in. In this case we use the trait Into<PathBuf> to specify that the function can take anything that can be turned into a PathBuf
or
2. The path does not get modified after it gets passed in. If this is the case then we use the trait AsRef<Path> to specify that anything that can be referenced as a Path is fine.

Into<PathBuf> and AsRef<Path> can both be a &str, String, Path, or PathBuf