### PR TITLE
feat: add --command flag to shell

### DIFF
--- a/nilla-cli-def/src/commands/shell.rs
+++ b/nilla-cli-def/src/commands/shell.rs
@@ -16,4 +16,10 @@ pub struct ShellArgs {
     pub name: String,
     #[arg(help = "System architecture (eg: x86_64-linux)")]
     pub system: Option<String>,
+    #[arg(
+        long,
+        short,
+        help = "Command and arguments to be executed, defaults to $SHELL",
+    )]
+    pub command: Option<String>,
 }

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -28,6 +28,14 @@ pub async fn shell_cmd(cli: &nilla_cli_def::Cli, args: &nilla_cli_def::commands:
         },
     };
 
+    let command = match &args.command {
+        Some(c) => c,
+        _ => &match std::env::var("SHELL") {
+            Ok(s) => s,
+            _ => "".to_string(),
+        },
+    };
+
     let attribute = format!("shells.\"{}\".result.\"{system}\"", args.name);
 
     match nix::exists_in_project("nilla.nix", entry.clone(), &attribute).await {
@@ -39,5 +47,5 @@ pub async fn shell_cmd(cli: &nilla_cli_def::Cli, args: &nilla_cli_def::commands:
     }
 
     info!("Entering shell {}", args.name);
-    nix::shell(&path, &attribute, ShellOpts { system: &system });
+    nix::shell(&path, &attribute, ShellOpts { system: &system, command: &command });
 }

--- a/src/util/nix.rs
+++ b/src/util/nix.rs
@@ -302,6 +302,7 @@ where
 
 pub struct ShellOpts<'a> {
     pub system: &'a str,
+    pub command: &'a str,
 }
 
 pub fn shell<P>(file: P, name: &str, opts: ShellOpts<'_>)
@@ -312,6 +313,10 @@ where
     if opts.system != "" {
         args.push("--system");
         args.push(opts.system);
+    }
+    if opts.command != "" {
+        args.push("--command");
+        args.push(opts.command);
     }
     args.push("-A");
     args.push(name);


### PR DESCRIPTION
The underlying `nix-shell` always runs a bash shell and on systems using another shell that's quite annoying. `nix-shell` and the newer `nix shell` command both have a `--command` that allows to specify another shell and the latter one also defaults to `$SHELL`.

This change mimics the behavior of `nix shell`.

Part of #12 