### PR TITLE
docs: fix README package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can add the Nilla CLI to your Nilla project and access using the following c
 # In any module of your project.
 { config }:
 let
-    nilla-cli-package = config.inputs.nilla-cli.packages.nilla.x86_64-linux;
+    nilla-cli-package = config.inputs.nilla-cli.packages.nilla-cli.x86_64-linux;
 in
 {
     config = {
@@ -36,7 +36,7 @@ let
     url = "https://github.com/nilla-nix/cli/archive/main.tar.gz";
     sha256 = "0000000000000000000000000000000000000000000000000000";
   });
-  nilla-cli-package = nilla-cli.packages.nilla.result.${pkgs.system};
+  nilla-cli-package = nilla-cli.packages.nilla-cli.result.${pkgs.system};
 in
 {
   environment.systemPackages = [

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,8 @@
     {
       packages = {
         x86_64-linux = rec {
-          nilla = project.packages.nilla-cli.result.x86_64-linux;
-          default = nilla;
+          nilla-cli = project.packages.nilla-cli.result.x86_64-linux;
+          default = nilla-cli;
         };
       };
     };


### PR DESCRIPTION
As of #3, the cli package has been called 'nilla-cli' in `nilla.nix` and `nilla` in the flake, however the README incorrectly refers to these the wrong way around

I have standardized on using `nilla-cli` as our package name here to match with the convention of nilla-nix/nixos and nilla-nix/home