### PR TITLE
Add aarch64-linux to nilla shell and flake outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,11 +6,11 @@
       project = import ./nilla.nix;
     in
     {
-      packages = {
-        x86_64-linux = rec {
-          nilla-cli = project.packages.nilla-cli.result.x86_64-linux;
-          default = nilla-cli;
-        };
-      };
+      packages = builtins.mapAttrs
+        (system: package: {
+          default = package;
+          nilla-cli = package;
+        })
+        project.packages.nilla-cli.result;
     };
 }

--- a/nilla.nix
+++ b/nilla.nix
@@ -55,7 +55,7 @@ nilla.create ({ config }: {
 
     shells.default = config.shells.nilla-cli;
     shells.nilla-cli = {
-      systems = [ "x86_64-linux" ];
+      systems = [ "x86_64-linux" "aarch64-linux" ];
 
       shell = { mkShell, fenix, bacon, pkg-config, ... }:
         mkShell {


### PR DESCRIPTION
- flake.nix: output all packages (by system) generated by nilla
  (instead of just hardcoded x86_64-linux)
- add aarch64-linux to list of nilla shell systems
  i tested `nilla shell` on an aarch64-linux pc and can compile successfully via `cargo build`