### PR TITLE
Exit with error code 1 on failure

### DIFF
--- a/src/util/nix.rs
+++ b/src/util/nix.rs
@@ -327,7 +327,6 @@ where
         .args(&args)
         .exec_replace()
         .unwrap();
-    std::process::exit(0);
 }
 
 pub struct GetMainProgramOpts<'a> {

--- a/src/util/project.rs
+++ b/src/util/project.rs
@@ -177,7 +177,7 @@ async fn resolve_git(info: GitInfo) -> anyhow::Result<Source> {
         bail!("{}", store_path.unwrap_err());
     };
 
-    let mut final_path = paths[0].clone();
+    let final_path = paths[0].clone();
 
     return Ok(Source::Git {
         info,


### PR DESCRIPTION
- convert `error!()` prints in subcommands to returning `Err`
- in `main()`: `exit(1)` when subcommands return `Err`, and print the `Err` via `error!()`