### PR TITLE
fix: use subpath to determine build type

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -104,7 +104,7 @@ pub async fn build_cmd(cli: &nilla_cli_def::Cli, args: &nilla_cli_def::commands:
 
     let build_type = determine_build_type(
         attribute,
-        path.iter().last().unwrap().to_str().unwrap(),
+        subpath.to_str().unwrap_or("nilla.nix"),
         entry.clone(),
     )
     .await;


### PR DESCRIPTION
I somehow missed this one in #15. It couldn't find the package when trying to build in a sub-directory.