### PR TITLE
feat: Add plugin discovery and listing functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ colored = "3.0.0"
 prettytable-rs = "0.10.0"
 which = "7.0.2"
 rand = "0.9.2"
+clap_complete = "4.5.47"
 
 [build-dependencies]
 nilla-cli-def = { version = "0.0.0-alpha.10", path = "./nilla-cli-def" }

--- a/completions/_nilla.zsh
+++ b/completions/_nilla.zsh
@@ -1,0 +1,14 @@
+#compdef nilla
+
+# Dynamic completion that discovers plugins at completion time
+# This ensures plugins installed after nilla-cli will be included in completions
+local nilla_cmd
+nilla_cmd=$(command -v nilla 2>/dev/null)
+if [[ -n "$nilla_cmd" ]]; then
+    local output
+    output=$($nilla_cmd completions --shell zsh 2>/dev/null)
+    if [[ -n "$output" ]]; then
+        # Eval the generated completion script (clap_complete generates a _nilla function)
+        eval "$output"
+    fi
+fi

--- a/completions/nilla.bash
+++ b/completions/nilla.bash
@@ -1,0 +1,16 @@
+# Dynamic bash completion that discovers plugins at completion time
+# This ensures plugins installed after nilla-cli will be included in completions
+_nilla() {
+    local nilla_cmd
+    nilla_cmd=$(command -v nilla 2>/dev/null)
+    if [[ -n "$nilla_cmd" ]]; then
+        local output
+        output=$($nilla_cmd completions --shell bash 2>/dev/null)
+        if [[ -n "$output" ]]; then
+            # Source the generated completion script (clap_complete generates a _nilla function)
+            eval "$output"
+        fi
+    fi
+}
+
+complete -F _nilla nilla

--- a/completions/nilla.elv
+++ b/completions/nilla.elv
@@ -1,0 +1,11 @@
+# Dynamic elvish completion that discovers plugins at completion time
+# This ensures plugins installed after nilla-cli will be included in completions
+# Elvish will source this file from $E:XDG_DATA_DIRS/elvish/lib/ automatically
+var nilla-cmd = (which nilla)
+if (not-eq $nilla-cmd $nil) {
+    var output = ($nilla-cmd completions --shell elvish 2>/dev/null)
+    if (not-eq $output $nil) {
+        # Eval the generated completion script (clap_complete generates elvish completion code)
+        eval $output
+    }
+}

--- a/completions/nilla.fish
+++ b/completions/nilla.fish
@@ -1,0 +1,11 @@
+# Dynamic fish completion that discovers plugins at completion time
+# This ensures plugins installed after nilla-cli will be included in completions
+# Fish will source this file automatically when vendor completions are enabled
+set nilla_cmd (command -v nilla 2>/dev/null)
+if test -n "$nilla_cmd"
+    set output ($nilla_cmd completions --shell fish 2>/dev/null)
+    if test -n "$output"
+        # Source the generated completion script (clap_complete generates fish completion functions)
+        eval $output
+    end
+end

--- a/nilla-cli-def/src/commands/mod.rs
+++ b/nilla-cli-def/src/commands/mod.rs
@@ -2,6 +2,7 @@ use clap::builder::styling::Style;
 
 pub mod build;
 pub mod completions;
+pub mod plugins;
 pub mod run;
 pub mod shell;
 pub mod show;

--- a/nilla-cli-def/src/commands/plugins.rs
+++ b/nilla-cli-def/src/commands/plugins.rs
@@ -1,0 +1,15 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Subcommand)]
+pub enum PluginsCommands {
+    /// List all available plugins
+    List,
+}
+
+#[derive(Debug, Args)]
+#[command(about = "Manage and list available plugins")]
+pub struct PluginsArgs {
+    #[command(subcommand)]
+    pub command: PluginsCommands,
+}
+

--- a/nilla-cli-def/src/lib.rs
+++ b/nilla-cli-def/src/lib.rs
@@ -2,7 +2,7 @@ pub mod commands;
 
 use clap::{ArgAction, Parser, Subcommand};
 use commands::{
-    build::BuildArgs, completions::CompletionsArgs, run::RunArgs, shell::ShellArgs, show::ShowArgs,
+    build::BuildArgs, completions::CompletionsArgs, plugins::PluginsArgs, run::RunArgs, shell::ShellArgs, show::ShowArgs,
 };
 
 #[derive(Parser, Debug)]
@@ -63,6 +63,7 @@ pub enum Commands {
     Build(BuildArgs),
     #[command(alias = "completion")]
     Completions(CompletionsArgs),
+    Plugins(PluginsArgs),
     #[command(external_subcommand)]
     External(Vec<String>),
 }

--- a/nilla.nix
+++ b/nilla.nix
@@ -47,6 +47,16 @@ nilla.create ({ config }: {
 
           postInstall = ''
             installManPage ./target/release-tmp/build/nilla-*/out/nilla*
+
+            # Install shell completions that dynamically discover plugins
+            mkdir -p $out/share/zsh/site-functions
+            cp ${./completions/_nilla.zsh} $out/share/zsh/site-functions/_nilla
+            mkdir -p $out/share/bash-completion/completions
+            cp ${./completions/nilla.bash} $out/share/bash-completion/completions/nilla
+            mkdir -p $out/share/fish/vendor_completions.d
+            cp ${./completions/nilla.fish} $out/share/fish/vendor_completions.d/nilla.fish
+            mkdir -p $out/share/elvish/lib
+            cp ${./completions/nilla.elv} $out/share/elvish/lib/nilla.elv
           '';
 
           cargoLock.lockFile = ./Cargo.lock;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod build;
+pub mod plugins;
 pub mod run;
 pub mod shell;
 pub mod show;

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -1,0 +1,41 @@
+use log::info;
+
+use crate::util::plugins;
+use crate::util::plugin_metadata;
+
+pub async fn plugins_list_cmd() -> anyhow::Result<()> {
+    info!("Discovering plugins...");
+
+    let discovered_plugins = plugins::discover_plugins()?;
+
+    if discovered_plugins.is_empty() {
+        println!("No plugins found in PATH.");
+        return Ok(());
+    }
+
+    println!("Found {} plugin(s):\n", discovered_plugins.len());
+
+    // Use a table format for better readability
+    println!("{:<20} {:<50} {:<15} {:<10}", "NAME", "PATH", "VERSION", "COMPLETIONS");
+    println!("{}", "-".repeat(95));
+
+    for plugin in &discovered_plugins {
+        let metadata = plugin_metadata::get_plugin_metadata(&plugin.path).await;
+
+        let version = metadata.version.unwrap_or_else(|| "unknown".to_string());
+        let completions_str = if metadata.supports_completions { "yes" } else { "no" };
+
+        let path_str = plugin.path.display().to_string();
+        // Truncate path if too long
+        let path_display = if path_str.len() > 48 {
+            format!("...{}", &path_str[path_str.len() - 45..])
+        } else {
+            path_str
+        };
+
+        println!("{:<20} {:<50} {:<15} {:<10}",
+            plugin.name, path_display, version, completions_str);
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ use clap::{
 use fern::colors::{Color, ColoredLevelConfig};
 use log::{LevelFilter, debug, error, trace};
 use nilla_cli_def::{Cli, Commands, commands::completions};
-use serde::de::value::UsizeDeserializer;
+use nilla::commands::plugins;
+use nilla::util::plugins::PluginInfo;
 
 const B: Style = Style::new().bold();
 const D: Style = Style::new().dimmed();
@@ -20,6 +21,47 @@ async fn main() -> anyhow::Result<()> {
         .info(Color::Blue)
         .warn(Color::Yellow)
         .error(Color::Red);
+
+    // Check for --help flag - but only intercept if it's not for an external subcommand
+    let args: Vec<String> = std::env::args().collect();
+    let is_help_request = args.iter().any(|arg| arg == "--help" || arg == "-h");
+
+    // If --help is requested, check if it's for an external subcommand (plugin)
+    // If the first argument (after program name) is a known plugin, let it pass through
+    if is_help_request && args.len() > 2 {
+        if let Ok(plugins) = nilla::util::plugins::discover_plugins() {
+            let first_arg = &args[1];
+            if plugins.iter().any(|p| p.name == *first_arg) {
+                // This is a help request for a plugin, let it pass through to external subcommand handling
+                // Don't intercept it here
+            } else {
+                // This is a help request for nilla itself, customize command to include plugins
+                let mut cmd = Cli::command();
+                if !plugins.is_empty() {
+                    let plugins_help = format_plugins_help(&plugins).await;
+                    cmd = cmd.after_help(plugins_help);
+                }
+                // Let clap handle --help with our customized command
+                let _ = cmd.print_long_help();
+                std::process::exit(0);
+            }
+        } else {
+            // No plugins found, just show nilla help
+            let _ = Cli::command().print_long_help();
+            std::process::exit(0);
+        }
+    } else if is_help_request {
+        // Help requested but no additional args, show nilla help with plugins
+        let mut cmd = Cli::command();
+        if let Ok(plugins) = nilla::util::plugins::discover_plugins() {
+            if !plugins.is_empty() {
+                let plugins_help = format_plugins_help(&plugins).await;
+                cmd = cmd.after_help(plugins_help);
+            }
+        }
+        let _ = cmd.print_long_help();
+        std::process::exit(0);
+    }
 
     let cli = Cli::parse();
     let mut filter_level = match cli.verbose {
@@ -67,6 +109,10 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_cli(cli: Cli) -> anyhow::Result<Option<i32>> {
+    // Check for --help flag
+    let args: Vec<String> = std::env::args().collect();
+    let is_help_request = args.iter().any(|arg| arg == "--help" || arg == "-h");
+
     trace!("Running {:?}", cli.command);
 
     match &cli.command {
@@ -75,18 +121,89 @@ async fn run_cli(cli: Cli) -> anyhow::Result<Option<i32>> {
             Commands::Shell(args) => nilla::commands::shell::shell_cmd(&cli, args).await?,
             Commands::Run(args) => nilla::commands::run::run_cmd(&cli, args).await?,
             Commands::Build(args) => nilla::commands::build::build_cmd(&cli, args).await?,
-            Commands::Completions(args) => completions::completions_cmd(args, &mut Cli::command()),
+            Commands::Completions(args) => {
+                let mut cmd = Cli::command();
+
+                // Discover plugins and add them as subcommands for completions
+                let discovered_plugins = nilla::util::plugins::discover_plugins().unwrap_or_default();
+
+                // Collect plugin metadata first (async) to get their commands
+                let mut plugin_metadata_vec = Vec::new();
+                for plugin in &discovered_plugins {
+                    let metadata = nilla::util::plugin_metadata::get_plugin_metadata(&plugin.path).await;
+                    plugin_metadata_vec.push((plugin, metadata));
+                }
+
+                // Build plugin commands with their subcommands (sync)
+                // Collect plugin info as static strings by leaking the allocations
+                // This is acceptable for completion generation which is a one-time operation
+                let plugin_commands: Vec<clap::Command> = plugin_metadata_vec.iter()
+                    .map(|(plugin, metadata)| {
+                        let name: &'static str = Box::leak(plugin.name.clone().into_boxed_str());
+                        let about: &'static str = Box::leak(format!("Plugin: {}", plugin.path.display()).into_boxed_str());
+                        let mut plugin_cmd = clap::Command::new(name).about(about);
+
+                        // Add plugin commands as subcommands so clap_complete can generate completions
+                        for cmd_info in &metadata.commands {
+                            let cmd_name_static: &'static str = Box::leak(cmd_info.name.clone().into_boxed_str());
+                            let cmd_desc_static: &'static str = Box::leak(cmd_info.description.clone().into_boxed_str());
+                            plugin_cmd = plugin_cmd.subcommand(
+                                clap::Command::new(cmd_name_static)
+                                    .about(cmd_desc_static)
+                            );
+                        }
+
+                        plugin_cmd
+                    })
+                    .collect();
+
+                for plugin_cmd in plugin_commands {
+                    cmd = cmd.subcommand(plugin_cmd);
+                }
+
+                // Generate base completions - this will include plugin commands
+                completions::completions_cmd(args, &mut cmd);
+            }
+            Commands::Plugins(args) => {
+                match &args.command {
+                    nilla_cli_def::commands::plugins::PluginsCommands::List => {
+                        plugins::plugins_list_cmd().await?;
+                    }
+                }
+            }
             Commands::External(items) => {
                 debug!("got external subcommand: {items:?}");
                 let name = format!("nilla-{}", items[0]);
+                let plugin_name = items[0].clone();
 
                 match which::which(&name) {
                     Ok(path) => {
                         debug!("found external subcommand: {path:?}");
-                        let exit_code = std::process::Command::new(path)
+
+                        // Always capture output and transform "nilla-<plugin>" to "nilla <plugin>"
+                        // This ensures consistent usage display regardless of how the plugin outputs help
+                        let output = tokio::process::Command::new(&path)
                             .args(&items[1..])
-                            .status()?;
-                        return Ok(exit_code.code());
+                            .output()
+                            .await?;
+
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+
+                        // Always transform "nilla-<plugin>" to "nilla <plugin>" in output
+                        let transformed_stdout = stdout
+                            .replace(&format!("nilla-{}", plugin_name), &format!("nilla {}", plugin_name));
+                        let transformed_stderr = stderr
+                            .replace(&format!("nilla-{}", plugin_name), &format!("nilla {}", plugin_name));
+
+                        if !transformed_stdout.is_empty() {
+                            print!("{}", transformed_stdout);
+                        }
+                        if !transformed_stderr.is_empty() {
+                            eprint!("{}", transformed_stderr);
+                        }
+
+                        return Ok(output.status.code());
                     }
                     Err(_) => {
                         bail!("External subcommand not found: {name}");
@@ -95,10 +212,118 @@ async fn run_cli(cli: Cli) -> anyhow::Result<Option<i32>> {
             }
         },
         None => {
-            println!("{}", Cli::command().render_long_help());
+            let help = Cli::command().render_long_help();
+            println!("{}", help);
+
+            // Append plugin information if any plugins are found
+            if let Ok(plugins) = nilla::util::plugins::discover_plugins() {
+                if !plugins.is_empty() {
+                    println!("\n{}", format_plugins_help(&plugins).await);
+                }
+            }
+
+            // If help was explicitly requested, exit successfully
+            if is_help_request {
+                return Ok(Some(0));
+            }
+
             bail!("No subcommand found");
         }
     };
 
     Ok(Some(0))
+}
+
+/// Get plugin-specific completions by calling each plugin's completion command
+async fn get_plugin_completions(
+    plugins: &[PluginInfo],
+    shell: clap_complete::Shell,
+) -> anyhow::Result<String> {
+    let mut all_completions = String::new();
+
+    for plugin in plugins {
+        // Get plugin metadata (cached, includes completion support check)
+        let metadata = nilla::util::plugin_metadata::get_plugin_metadata(&plugin.path).await;
+
+        if !metadata.supports_completions {
+            continue;
+        }
+
+        // Try to get completions from the plugin
+        let completion_output = tokio::process::Command::new(&plugin.path)
+            .arg("completion")
+            .arg(shell_to_string(shell))
+            .output()
+            .await;
+
+        match completion_output {
+            Ok(output) if output.status.success() => {
+                let plugin_completions = String::from_utf8_lossy(&output.stdout);
+                if !plugin_completions.trim().is_empty() {
+                    // Add a comment to identify which plugin these completions are from
+                    all_completions.push_str(&format!("\n# Completions for plugin: {}\n", plugin.name));
+                    all_completions.push_str(&plugin_completions);
+                }
+            }
+            _ => {
+                // Plugin doesn't support completions or failed - skip silently
+                debug!("Plugin {} does not support completions or failed", plugin.name);
+            }
+        }
+    }
+
+    Ok(all_completions)
+}
+
+/// Convert Shell enum to string for plugin commands
+/// Only supports: bash, elvish, fish, powershell, zsh
+fn shell_to_string(shell: clap_complete::Shell) -> &'static str {
+    use clap_complete::Shell;
+    match shell {
+        Shell::Bash => "bash",
+        Shell::Zsh => "zsh",
+        Shell::Fish => "fish",
+        Shell::PowerShell => "powershell",
+        Shell::Elvish => "elvish",
+        // Handle any other shells by falling back to bash
+        _ => "bash",
+    }
+}
+
+/// Format plugin information for help output
+async fn format_plugins_help(plugins: &[PluginInfo]) -> String {
+    use clap::builder::styling::Style;
+    const HEADER_STYLE: Style = Style::new().bold().underline();
+
+    let mut output = format!("{HEADER_STYLE}Available Plugins{HEADER_STYLE:#}\n");
+
+    for plugin in plugins {
+        // Get plugin metadata (cached)
+        let metadata = nilla::util::plugin_metadata::get_plugin_metadata(&plugin.path).await;
+
+        output.push_str(&format!("  {}\n", plugin.name));
+
+        // Show usage if available
+        if let Some(usage) = &metadata.usage {
+            output.push_str(&format!("    {}\n", usage));
+        }
+
+        // Show commands if available
+        if !metadata.commands.is_empty() {
+            let cmd_names: Vec<String> = metadata.commands.iter().map(|c| c.name.clone()).collect();
+            output.push_str(&format!("    Commands: {}\n", cmd_names.join(", ")));
+        }
+
+        // Show examples if available
+        if !metadata.examples.is_empty() {
+            output.push_str(&format!("    Examples: {}\n", metadata.examples.join("; ")));
+        }
+
+        output.push_str("\n");
+    }
+
+    output.push_str(&format!("  Use `nilla plugins list` to see all plugins with details.\n"));
+    output.push_str(&format!("  Use `nilla <plugin> --help` to see plugin-specific help.\n"));
+
+    output
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,7 @@
 pub mod errors;
 pub mod git;
 pub mod nix;
+pub mod plugin_metadata;
+pub mod plugins;
 pub mod project;
 pub mod search;

--- a/src/util/plugin_metadata.rs
+++ b/src/util/plugin_metadata.rs
@@ -1,0 +1,166 @@
+use std::path::Path;
+use tokio::process::Command as TokioCommand;
+
+/// Command information with name and description
+#[derive(Debug, Clone)]
+pub struct CommandInfo {
+    pub name: String,
+    pub description: String,
+}
+
+/// Cached metadata about a plugin
+#[derive(Debug, Clone)]
+pub struct PluginMetadata {
+    pub help_text: String,
+    pub version: Option<String>,
+    pub usage: Option<String>,
+    pub commands: Vec<CommandInfo>,
+    pub examples: Vec<String>,
+    pub supports_completions: bool,
+}
+
+/// Execute a plugin command and return its output
+async fn execute_plugin_command(plugin_path: &Path, args: &[&str]) -> Option<String> {
+    let output = TokioCommand::new(plugin_path)
+        .args(args)
+        .output()
+        .await
+        .ok()?;
+
+    if output.status.success() {
+        String::from_utf8(output.stdout).ok()
+    } else {
+        None
+    }
+}
+
+/// Parse plugin help text to extract usage, commands, examples, and completion support
+fn parse_plugin_help(help_text: &str, plugin_name: &str) -> (Option<String>, Vec<CommandInfo>, Vec<String>, bool) {
+    let mut usage = None;
+    let mut commands = Vec::new();
+    let mut examples = Vec::new();
+    let supports_completions = help_text.contains("completion") || help_text.contains("completions");
+
+    // Extract Usage line and transform it to use "nilla <plugin>" format
+    for line in help_text.lines() {
+        let line = line.trim();
+        if line.starts_with("Usage:") || line.starts_with("USAGE:") {
+            // Replace "nilla-<plugin>" with "nilla <plugin>" in the usage line
+            // Use regex-like replacement: find "nilla-<word>" and replace with "nilla <word>"
+            let transformed_usage = line
+                .replace(&format!("nilla-{}", plugin_name), &format!("nilla {}", plugin_name));
+            usage = Some(transformed_usage);
+            break;
+        }
+    }
+
+    // Extract commands from Commands: section with their descriptions
+    if let Some(commands_start) = help_text.find("Commands:") {
+        let commands_section = &help_text[commands_start..];
+        if let Some(commands_end) = commands_section.find("\n\n") {
+            let commands_text = &commands_section[..commands_end];
+            commands = commands_text
+                .lines()
+                .skip(1)
+                .filter_map(|line| {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() || trimmed.starts_with("Options:") {
+                        None
+                    } else {
+                        // Parse command name and description
+                        // Format is typically: "  command_name    Description text"
+                        let parts: Vec<&str> = trimmed.split_whitespace().collect();
+                        if parts.is_empty() {
+                            None
+                        } else {
+                            let name = parts[0].to_string();
+
+                            // Skip "help" command as clap adds it automatically
+                            if name == "help" {
+                                return None;
+                            }
+
+                            // Description is everything after the command name
+                            // Find where the description starts (after multiple spaces or after first word)
+                            let desc_start = trimmed.find(parts[0]).unwrap_or(0) + parts[0].len();
+                            let description = trimmed[desc_start..].trim_start().to_string();
+
+                            Some(CommandInfo {
+                                name,
+                                description: if description.is_empty() { "".to_string() } else { description },
+                            })
+                        }
+                    }
+                })
+                .collect();
+        }
+    }
+
+    // Extract examples from Examples: section
+    if let Some(examples_start) = help_text.find("Examples:") {
+        let examples_section = &help_text[examples_start..];
+        if let Some(examples_end) = examples_section.find("\n\n") {
+            let examples_text = &examples_section[..examples_end];
+            examples = examples_text
+                .lines()
+                .skip(1)
+                .filter_map(|line| {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() || trimmed.starts_with("Options:") || trimmed.starts_with("Commands:") {
+                        None
+                    } else if trimmed.starts_with("#") || trimmed.starts_with("$") {
+                        // Skip comment lines and shell prompt lines
+                        None
+                    } else if trimmed.len() > 5 {
+                        Some(trimmed.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+        }
+    }
+
+    (usage, commands, examples, supports_completions)
+}
+
+/// Clean version string by removing program name prefix
+fn clean_version(version: &str) -> String {
+    if let Some(last_space) = version.rfind(' ') {
+        version[last_space + 1..].to_string()
+    } else {
+        version.to_string()
+    }
+}
+
+/// Get all metadata for a plugin by executing commands once and caching results
+pub async fn get_plugin_metadata(plugin_path: &Path) -> PluginMetadata {
+    // Execute --help and --version in parallel
+    let (help_result, version_result) = tokio::join!(
+        execute_plugin_command(plugin_path, &["--help"]),
+        execute_plugin_command(plugin_path, &["--version"])
+    );
+
+    let help_text = help_result.unwrap_or_default();
+    let version = version_result
+        .map(|v| clean_version(v.trim()))
+        .filter(|v| !v.is_empty());
+
+    // Extract plugin name from path (e.g., "nilla-home" -> "home")
+    let plugin_name = plugin_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .and_then(|s| s.strip_prefix("nilla-"))
+        .unwrap_or("plugin");
+
+    let (usage, commands, examples, supports_completions) = parse_plugin_help(&help_text, plugin_name);
+
+    PluginMetadata {
+        help_text,
+        version,
+        usage,
+        commands,
+        examples,
+        supports_completions,
+    }
+}

--- a/src/util/plugins.rs
+++ b/src/util/plugins.rs
@@ -1,0 +1,104 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use anyhow::Result;
+use log::debug;
+
+/// Information about a discovered plugin
+#[derive(Debug, Clone)]
+pub struct PluginInfo {
+    pub name: String,
+    pub path: PathBuf,
+}
+
+/// Discover all available plugins in PATH
+///
+/// Searches PATH for executables matching the pattern `nilla-*` and returns
+/// information about each discovered plugin.
+pub fn discover_plugins() -> Result<Vec<PluginInfo>> {
+    let path_var = std::env::var("PATH")?;
+    // PATH separator is ':' on Unix and ';' on Windows
+    let path_dirs: Vec<&str> = if cfg!(windows) {
+        path_var.split(';').collect()
+    } else {
+        path_var.split(':').collect()
+    };
+
+    let mut plugins = Vec::new();
+    let mut seen_names = HashSet::new();
+
+    for dir in path_dirs {
+        let dir_path = Path::new(dir);
+        if !dir_path.is_dir() {
+            continue;
+        }
+
+        let Ok(entries) = std::fs::read_dir(dir_path) else {
+            continue;
+        };
+
+        for entry in entries {
+            let Ok(entry) = entry else {
+                continue;
+            };
+
+            let path = entry.path();
+
+            // Check if it's an executable file starting with "nilla-"
+            if path.is_file() {
+                // Extract file_name as owned String before moving path
+                let file_name_opt = path.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|s| s.to_string());
+
+                if let Some(file_name) = file_name_opt {
+                    if file_name.starts_with("nilla-") && file_name != "nilla" {
+                        // Check if it's executable (on Unix-like systems)
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::PermissionsExt;
+                            let metadata = match std::fs::metadata(&path) {
+                                Ok(m) => m,
+                                Err(_) => continue,
+                            };
+                            if metadata.permissions().mode() & 0o111 == 0 {
+                                continue; // Not executable
+                            }
+                        }
+
+                        let plugin_name = file_name.strip_prefix("nilla-").unwrap().to_string();
+
+                        // Avoid duplicates (same plugin name in different PATH directories)
+                        if seen_names.insert(plugin_name.clone()) {
+                            // Store original path for debug before moving
+                            let path_for_debug = path.clone();
+                            let canonicalized_path = path.canonicalize().unwrap_or_else(|_| path);
+                            plugins.push(PluginInfo {
+                                name: plugin_name,
+                                path: canonicalized_path,
+                            });
+                            debug!("Discovered plugin: {} at {:?}", file_name, path_for_debug);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Sort by name for consistent output
+    plugins.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Ok(plugins)
+}
+
+/// Get plugin information by name
+pub fn find_plugin(name: &str) -> Result<Option<PluginInfo>> {
+    let plugin_name = format!("nilla-{}", name);
+
+    match which::which(&plugin_name) {
+        Ok(path) => Ok(Some(PluginInfo {
+            name: name.to_string(),
+            path: path.canonicalize().unwrap_or(path),
+        })),
+        Err(_) => Ok(None),
+    }
+}


### PR DESCRIPTION
# Add Plugin Discovery and Integration

This PR adds comprehensive plugin discovery and integration functionality to `nilla-cli`, making it easy for users to discover and use plugins like `nilla-home` and `nilla-nixos`.
This solves the issue #22.

## Features

### Plugin Discovery

- Automatically discovers `nilla-*` executables in the system PATH
- Caches plugin metadata (version, usage, commands, examples) to avoid redundant process calls

### Plugin Listing

- New `nilla plugins list` command displays all available plugins in a formatted table
- Shows plugin name, path, version, completion support, and available commands

### Help Integration

- Plugin information is automatically included in `nilla --help` output
- Displays usage, commands, and examples for each discovered plugin
- `nilla <plugin> --help` correctly shows the plugin's help instead of nilla's help

```
Usage: nilla [OPTIONS] [COMMAND]

[...]

Available Plugins
  home
    Usage: nilla home [OPTIONS] [COMMAND]
    Commands: switch, build, completions, help

  nixos
    Usage: nilla nixos [OPTIONS] [COMMAND]
    Commands: switch, test, build, completions, help

  Use `nilla plugins list` to see all plugins with details.
  Use `nilla <plugin> --help` to see plugin-specific help.
```

### Shell Completions

- Plugins appear as top-level commands in shell completions (e.g., `nilla <TAB> home <TAB>`)
- Plugin commands are included in completions (e.g., `nilla home switch <TAB>`)
- Completions are generated by nilla-cli itself, ensuring consistent behavior across shells

```
nilla <TAB>
build        -- Build a package from a Nilla project
completions  -- Generate autocompletions for your shell
help         -- Print this message or the help of the given subcommand(s)
home         -- Plugin: /nix/store/465il15cv5x9bldi5pm0vnnj003b56p7-nilla-home-0.0.0/bin/nilla-home
nixos        -- Plugin: /nix/store/1nc4fk1x7inv8h4vzv167wvbdv5szyv2-nilla-nixos-0.0.0/bin/nilla-nixos
plugins      -- Manage and list available plugins
run          -- Run a package's main program
shell        -- Start a development shell from a Nilla project
show         -- Show information about a Nilla project
```

```
nilla nixos <TAB>
build              -- Build a NixOS system
completions        -- Generate autocompletions for your shell
help               -- Print this message or the help of the given subcommand(s)
switch             -- Build, install, and switch into a system
test               -- Test a system
```

## Technical Details

- Plugin metadata is extracted by parsing `--help` and `--version` output
- Metadata parsing focuses on robust sections: "Usage:", "Commands:", and "Examples:"
- Plugin commands are dynamically added to the completion structure
- Help output transforms plugin usage from `nilla-<plugin>` to `nilla <plugin>` format
