### PR TITLE
chore: upgrade nilla, update fenix

### DIFF
--- a/npins/default.nix
+++ b/npins/default.nix
@@ -65,7 +65,9 @@ let
         if pkgs == null then
           {
             inherit (builtins) fetchTarball fetchurl;
-            # For some fucking reason, fetchGit has a different signature than the other builtin fetchers …
+            # Frustratingly, due to flakes and `fetchTree`, `fetchGit`
+            # has a different signature than the other builtin
+            # fetchers
             fetchGit = args: (builtins.fetchGit args).outPath;
           }
         else
@@ -95,7 +97,6 @@ let
               };
           };
 
-      # Dispatch to the correct code path based on the type
       path =
         if spec.type == "Git" then
           mkGitSource fetchers spec
@@ -105,8 +106,8 @@ let
           mkPyPiSource fetchers spec
         else if spec.type == "Channel" then
           mkChannelSource fetchers spec
-        else if spec.type == "Tarball" then
-          mkTarballSource fetchers spec
+        else if spec.type == "Url" || spec.type == "MutableUrl" then
+          mkUrlSource fetchers spec
         else if spec.type == "Container" then
           mkContainerSource pkgs spec
         else
@@ -145,6 +146,8 @@ let
             "https://github.com/${repository.owner}/${repository.repo}.git"
           else if repository.type == "GitLab" then
             "${repository.server}/${repository.repo_path}.git"
+          else if repository.type == "Forgejo" then
+            "${repository.server}/${repository.owner}/${repository.repo}.git"
           else
             throw "Unrecognized repository type ${repository.type}";
         urlToName =
@@ -190,16 +193,20 @@ let
       sha256 = hash;
     };
 
-  mkTarballSource =
-    { fetchTarball, ... }:
+  mkUrlSource =
     {
-      url,
-      locked_url ? url,
-      hash,
+      fetchTarball,
+      fetchurl,
       ...
     }:
-    fetchTarball {
-      url = locked_url;
+    {
+      url,
+      hash,
+      unpack,
+      ...
+    }:
+    (if unpack then fetchTarball else fetchurl) {
+      inherit url;
       sha256 = hash;
     };
 
@@ -209,16 +216,22 @@ let
       image_name,
       image_tag,
       image_digest,
+      hash,
       ...
-    }:
+    }@args:
     if pkgs == null then
       builtins.throw "container sources require passing in a Nixpkgs value: https://github.com/andir/npins/blob/master/README.md#using-the-nixpkgs-fetchers"
     else
-      pkgs.dockerTools.pullImage {
-        imageName = image_name;
-        imageDigest = image_digest;
-        finalImageTag = image_tag;
-      };
+      pkgs.dockerTools.pullImage (
+        {
+          imageName = image_name;
+          imageDigest = image_digest;
+          finalImageTag = image_tag;
+          hash = hash;
+        }
+        // (if args.arch or null != null then { arch = args.arch; } else { })
+      );
+
 in
 mkFunctor (
   {
@@ -229,7 +242,7 @@ mkFunctor (
       if builtins.isPath input then
         # while `readFile` will throw an error anyways if the path doesn't exist,
         # we still need to check beforehand because *our* error can be caught but not the one from the builtin
-        # *piegames sighs*
+        # See: <https://git.lix.systems/lix-project/lix/issues/1098>
         if builtins.pathExists input then
           builtins.fromJSON (builtins.readFile input)
         else
@@ -240,7 +253,7 @@ mkFunctor (
         throw "Unsupported input type ${builtins.typeOf input}, must be a path or an attrset";
     version = data.version;
   in
-  if version == 7 then
+  if version == 8 then
     builtins.mapAttrs (name: spec: mkFunctor (mkSource name spec)) data.pins
   else
     throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "monthly",
       "submodules": false,
-      "revision": "78d518f5ca32a86dc767de481160dbae640c70cf",
-      "url": "https://github.com/nix-community/fenix/archive/78d518f5ca32a86dc767de481160dbae640c70cf.tar.gz",
-      "hash": "sha256-EBpe7sXCPLs+qVePXbA7kc+Kmpmp0pWysEpjjEWTK+E="
+      "revision": "8160d67d2693a1f7ea219db159ccdc29ae632918",
+      "url": "https://github.com/nix-community/fenix/archive/8160d67d2693a1f7ea219db159ccdc29ae632918.tar.gz",
+      "hash": "sha256-1y6LHeumqA2lnUZap2yor+g4jMFtno5mx119LEv+dQQ="
     },
     "nilla": {
       "type": "Git",
@@ -40,5 +40,5 @@
       "hash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU="
     }
   },
-  "version": 7
+  "version": 8
 }


### PR DESCRIPTION
the rust nightly toolchain build was failing on just one of my machines, succeeding everywhere else. this fixes it. I don't know what was wrong, but given that it's a nightly, I don't feel that it's necessary to.

Force-Push: I am mirroring this to my personal infra. my personal infra does not have CI. this line prevents it from thinking it should. sorry for the noise.
Change-Id: I7eca699dc174f38f0547aaa97de3b0aa1b7e5ce1